### PR TITLE
Draft: Add content page and rearrange content

### DIFF
--- a/docs/course-content.md
+++ b/docs/course-content.md
@@ -12,6 +12,7 @@ The course is about simulation software. More precisely, we discuss the software
 
 - Lecture and lab organization
 - What is research software engineering and what is special about it?
+- Why do we need research software engineering?
 
 ### Version Control
 
@@ -33,32 +34,32 @@ The course is about simulation software. More precisely, we discuss the software
 
 - Comprehending the necessity to package code
 - Using package managers to package code and upload to a remote managing platform
-- How to automatize compilation of codes.
+- What package managers do exist for high-performance computing applications?
 - How to easily add your code to package managers for reproducibility.
-- Reproducible builds/environments?
+- How to create reproducible builds or environments?
 
 ### Documentation
 
 - Understand what you want to document and to document different types aspects (code, development, API, usage).
 - The students can choose the right tool for the documentation needs.
-- The students now common documentation tools for C++ and Python.
-- The students now fundamentals of technical writing.
+- The students know common documentation tools for C++ and Python.
+- The students know fundamentals of technical writing.
 - Students understand the importance of documentation for themselves and others.
 
 ### Testing and Continuous Integration
 
 - What type of test to use for what use case.
-- Importance of tests.
-- Automatic testing using GitHub and GitLab.
-- Different testing frameworks.
+- Why are tests important?
+- The students learn how to automate tests using GitHub and GitLab.
+- The students have an overview over different testing frameworks.
 
 ### Legal, Archiving, Community, and More
 
 - Understand why it is important to add a license to one's code.
-- Importance of long term storage of data.
-- Data and metadata documentation using DataVerse.
-- Importance of reproducibility.
-- How to build and interact with user to build a community.
+- Importance of long term storage/availability of data and ow to make it available.
+- Data and metadata documentation using DataVerse ([DaRUS](https://darus.uni-stuttgart.de/)).
+- Importance of reproducibility of research.
+- How to build and interact with users to build a community.
 
 ## Assignments and lab work
 

--- a/docs/course-content.md
+++ b/docs/course-content.md
@@ -4,24 +4,25 @@ title: Course content
 description: >-
     Information about course, exercise and lab content
 ---
-## Course's contents
+## Lecture and lab assignments
 
-The course is about simulation software. More precisely, we discuss the software tools used to ensure good software engineering for open-source simulation software such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2. This is not a course focused on programming and programming paradigms, but on the techniques and the correspnding tools. Some examples are version control (Git, GitHub, GitLab), virtualization/containerization (Docker), continuous integration (GitHub Actions, GitLab CI), or documentation  (Jekyll, mkdocs, sphinx). More specifically, the course aims to explain the topics described below.
+The lecture and the accompanying lab assignments are organized in 7 chapters.
 
-### Organization and Introduction to RSE
 
-- Lecture and lab organization
+### 1. Organization and Introduction to RSE
+
+- Lecture, lab organization, and the challenge
 - What is research software engineering and what is special about it?
 - Why do we need research software engineering?
 
-### Version Control
+### 2. Version Control
 
 - Refresh and organize students' existing knowledge on git (learn how to learn more).
 - Students can explain difference between merge and rebase and when to use what.
 - How to use git workflows to organize research software development in a team.
 - Get to know a few useful GitHub/GitLab standards and a few helpful tools.
 
-### Virtualization and Containerization
+### 3. Virtualization and Containerization
 
 - What is the difference between virtualization and containers?
 - When to use virtual machines and when containers.
@@ -30,7 +31,7 @@ The course is about simulation software. More precisely, we discuss the software
 - Understand pros and cons of different container technologies.
 - Student can set up their own containers tailored to their requirements.
 
-### Building and Packaging
+### 4. Building and Packaging
 
 - Comprehending the necessity to package code
 - Using package managers to package code and upload to a remote managing platform
@@ -38,37 +39,36 @@ The course is about simulation software. More precisely, we discuss the software
 - How to easily add your code to package managers for reproducibility.
 - How to create reproducible builds or environments?
 
-### Documentation
+### 5. Documentation
 
-- Understand what you want to document and to document different types aspects (code, development, API, usage).
+- Understand what you want to document and that there are different aspects (code, development, API, usage).
 - The students can choose the right tool for the documentation needs.
 - The students know common documentation tools for C++ and Python.
 - The students know fundamentals of technical writing.
 - Students understand the importance of documentation for themselves and others.
 
-### Testing and Continuous Integration
+### 6. Testing and Continuous Integration
 
 - What type of test to use for what use case.
 - Why are tests important?
 - The students learn how to automate tests using GitHub and GitLab.
 - The students have an overview over different testing frameworks.
 
-### Legal, Archiving, Community, and More
+### 7. Legal, Archiving, Community, and More
 
 - Understand why it is important to add a license to one's code.
+- Which license to pick for your code.
 - Importance of long term storage/availability of data and ow to make it available.
 - Data and metadata documentation using DataVerse ([DaRUS](https://darus.uni-stuttgart.de/)).
 - Importance of reproducibility of research.
 - How to build and interact with users to build a community.
 
-## Assignments and lab work
+## The challenge
 
-There are two types of assignments. We have smaller (almost) weekly lab work, which helps you to get familiar with the presented software engineering concepts and tools.
-
-Parallel to the lab work, you work on an individual challenge, where you apply the learned concepts and tools with the ultimate goal to contribute to a large-scale community simulation software package. The challenge is structured in three parts, whereas each part is completed by a short presentation of the intermediate results in class:
+Parallel to the weekly lab work, you work on an individual challenge, where you apply the learned concepts and tools with the ultimate goal to contribute to a large-scale community simulation software package. The challenge is structured in three parts, whereas each part is completed by a short presentation of the intermediate results in class:
 
 1. You get acquainted with the basic functionality of a large-scale simulation software package (such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2) by studying tutorials and documentation (first quarter of the course)
 2. You analyze the RSE infrastructure and the development cycle of the software package (second quarter of the course).
 3. You contribute to the software package. The contribution can be small, but should not be trivial. Possible examples: Adding a new tutorial, extending the documentation, working on a "good first issue", adding support of a new package manager. Important is to properly go through all development steps if possible (contact community, open issue, open pull request, test, review, merge).
 
-The lab work and assignments are an important part of the course. There will be **no** written or oral exam at the end of the lecture. Instead, you are evaluated continuously based on the lab work and assignments.
+The weekly lab work and assignments are an important part of the course. There will be **no** written or oral exam at the end of the lecture. Instead, you are evaluated continuously based on the lab work and the challenge.

--- a/docs/course-content.md
+++ b/docs/course-content.md
@@ -10,6 +10,9 @@ The course is about simulation software. More precisely, we discuss the software
 
 ### Organization and Introduction to RSE
 
+- Lecture and lab organization
+- What is research software engineering and what is special about it?
+
 ### Version Control
 
 - Refresh and organize students' existing knowledge on git (learn how to learn more).

--- a/docs/course-content.md
+++ b/docs/course-content.md
@@ -4,10 +4,10 @@ title: Course content
 description: >-
     Information about course, exercise and lab content
 ---
+
 ## Lecture and lab assignments
 
 The lecture and the accompanying lab assignments are organized in 7 chapters.
-
 
 ### 1. Organization and Introduction to RSE
 

--- a/docs/course-content.md
+++ b/docs/course-content.md
@@ -63,13 +63,12 @@ The course is about simulation software. More precisely, we discuss the software
 
 ## Assignments and lab work
 
-There are two types of assignments. We have smaller weekly lab work, which helps you to get familiar with the presented software engineering concepts and tools.
+There are two types of assignments. We have smaller (almost) weekly lab work, which helps you to get familiar with the presented software engineering concepts and tools.
 
 Parallel to the lab work, you work on an individual challenge, where you apply the learned concepts and tools with the ultimate goal to contribute to a large-scale community simulation software package. The challenge is structured in three parts, whereas each part is completed by a short presentation of the intermediate results in class:
 
 1. You get acquainted with the basic functionality of a large-scale simulation software package (such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2) by studying tutorials and documentation (first quarter of the course)
 2. You analyze the RSE infrastructure and the development cycle of the software package (second quarter of the course).
 3. You contribute to the software package. The contribution can be small, but should not be trivial. Possible examples: Adding a new tutorial, extending the documentation, working on a "good first issue", adding support of a new package manager. Important is to properly go through all development steps if possible (contact community, open issue, open pull request, test, review, merge).
-
 
 The lab work and assignments are an important part of the course. There will be **no** written or oral exam at the end of the lecture. Instead, you are evaluated continuously based on the lab work and assignments.

--- a/docs/course-content.md
+++ b/docs/course-content.md
@@ -1,0 +1,71 @@
+---
+layout: page
+title: Course content
+description: >-
+    Information about course, exercise and lab content
+---
+## Course's contents
+
+The course is about simulation software. More precisely, we discuss the software tools used to ensure good software engineering for open-source simulation software such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2. This is not a course focused on programming and programming paradigms, but on the techniques and the correspnding tools. Some examples are version control (Git, GitHub, GitLab), virtualization/containerization (Docker), continuous integration (GitHub Actions, GitLab CI), or documentation  (Jekyll, mkdocs, sphinx). More specifically, the course aims to explain the topics described below.
+
+### Organization and Introduction to RSE
+
+### Version Control
+
+- Refresh and organize students' existing knowledge on git (learn how to learn more).
+- Students can explain difference between merge and rebase and when to use what.
+- How to use git workflows to organize research software development in a team.
+- Get to know a few useful GitHub/GitLab standards and a few helpful tools.
+
+### Virtualization and Containerization
+
+- What is the difference between virtualization and containers?
+- When to use virtual machines and when containers.
+- How to work with virtual machines (VirtualBox) and how to manage these with Vagrant.
+- Building containers with Docker and Singularity.
+- Understand pros and cons of different container technologies.
+- Student can set up their own containers tailored to their requirements.
+
+### Building and Packaging
+
+- Comprehending the necessity to package code
+- Using package managers to package code and upload to a remote managing platform
+- How to automatize compilation of codes.
+- How to easily add your code to package managers for reproducibility.
+- Reproducible builds/environments?
+
+### Documentation
+
+- Understand what you want to document and to document different types aspects (code, development, API, usage).
+- The students can choose the right tool for the documentation needs.
+- The students now common documentation tools for C++ and Python.
+- The students now fundamentals of technical writing.
+- Students understand the importance of documentation for themselves and others.
+
+### Testing and Continuous Integration
+
+- What type of test to use for what use case.
+- Importance of tests.
+- Automatic testing using GitHub and GitLab.
+- Different testing frameworks.
+
+### Legal, Archiving, Community, and More
+
+- Understand why it is important to add a license to one's code.
+- Importance of long term storage of data.
+- Data and metadata documentation using DataVerse.
+- Importance of reproducibility.
+- How to build and interact with user to build a community.
+
+## Assignments and lab work
+
+There are two types of assignments. We have smaller weekly lab work, which helps you to get familiar with the presented software engineering concepts and tools.
+
+Parallel to the lab work, you work on an individual challenge, where you apply the learned concepts and tools with the ultimate goal to contribute to a large-scale community simulation software package. The challenge is structured in three parts, whereas each part is completed by a short presentation of the intermediate results in class:
+
+1. You get acquainted with the basic functionality of a large-scale simulation software package (such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2) by studying tutorials and documentation (first quarter of the course)
+2. You analyze the RSE infrastructure and the development cycle of the software package (second quarter of the course).
+3. You contribute to the software package. The contribution can be small, but should not be trivial. Possible examples: Adding a new tutorial, extending the documentation, working on a "good first issue", adding support of a new package manager. Important is to properly go through all development steps if possible (contact community, open issue, open pull request, test, review, merge).
+
+
+The lab work and assignments are an important part of the course. There will be **no** written or oral exam at the end of the lecture. Instead, you are evaluated continuously based on the lab work and assignments.

--- a/docs/course-information.md
+++ b/docs/course-information.md
@@ -15,12 +15,6 @@ Read more:
 - Association of German Research Software Engineers: [de-RSE](https://de-rse.org/en/)
 - [Position paper of de-RSE](https://f1000research.com/articles/9-295/v2)
 
-
-
-## Content of the course
-
-The course is about simulation software. More precisely, we discuss the software tools used to ensure good software engineering for open-source simulation software such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2. This is not a course focused on programming and programming paradigms, but on the techniques and the correspnding tools. Some examples are version control (Git, GitHub, GitLab), virtualization/containerization (Docker), continuous integration (GitHub Actions, GitLab CI), or documentation  (Jekyll, mkdocs, sphinx).
-
 ## Target audience
 
 This course is aimed at master-level students from Computer Science, Simulation Technology and related fields, but is also open to PhD students or anyone else interested. We expect you to have some knowledge in software development, basic tools and programming. However, we also give you extra information or point to additional resources if you have the feeling you need to catch up with some topic.
@@ -36,19 +30,6 @@ This course is aimed at master-level students from Computer Science, Simulation 
 All teaching resources are (will be) available online on GitHub and on this homepage.
 
 We encourage **you** to help us extend these resources and fix mistakes.
-
-## Assignments and lab work
-
-There are two types of assignments. We have smaller weekly lab work, which helps you to get familiar with the presented software engineering concepts and tools.
-
-Parallel to the lab work, you work on an individual challenge, where you apply the learned concepts and tools with the ultimate goal to contribute to a large-scale community simulation software package. The challenge is structured in three parts, whereas each part is completed by a short presentation of the intermediate results in class:
-
-1. You get acquainted with the basic functionality of a large-scale simulation software package (such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2) by studying tutorials and documentation (first quarter of the course)
-2. You analyze the RSE infrastructure and the development cycle of the software package (second quarter of the course).
-3. You contribute to the software package. The contribution can be small, but should not be trivial. Possible examples: Adding a new tutorial, extending the documentation, working on a "good first issue", adding support of a new package manager. Important is to properly go through all development steps if possible (contact community, open issue, open pull request, test, review, merge).
-
-
-The lab work and assignments are an important part of the course. There will be **no** written or oral exam at the end of the lecture. Instead, you are evaluated continuously based on the lab work and assignments.
 
 ## Additional information for SimTech students
 

--- a/docs/course-information.md
+++ b/docs/course-information.md
@@ -7,7 +7,6 @@ description: >-
 
 ## About
 
-
 Software is an integral part of nowadays research. A [UK survey in 2014](https://zenodo.org/record/1183562#.YTHZ91uxUUE) found that 7 out of 10 researchers could not conduct research without software. However, research software engineering (RSE) does not yet get the necessary attention in research and in teaching. All this applies to simulation software in particular.
 
 Read more:
@@ -34,4 +33,3 @@ We encourage **you** to help us extend these resources and fix mistakes.
 ## Additional information for SimTech students
 
 You might also be interested in the course *Sustainable Development of Simulation Software* by Bernd Flemisch and Dennis Gläser, which is starting in summer term 2022. Their course has a stronger focus on software engineering patterns and project work in C++ for simulation software. Our course *Simulation Software Engineering* focuses more on the tools commonly used in the development of simulation software. The course of Flemisch/Gläser is **not** a prerequisite to follow our course on simulation software engineering and neither vice versa. We encourage you, however, to follow both courses if you are interested in the topic.
-

--- a/docs/course-information.md
+++ b/docs/course-information.md
@@ -5,7 +5,7 @@ description: >-
     Course policies and information.
 ---
 
-## About
+## Research Software Engineering
 
 Software is an integral part of nowadays research. A [UK survey in 2014](https://zenodo.org/record/1183562#.YTHZ91uxUUE) found that 7 out of 10 researchers could not conduct research without software. However, research software engineering (RSE) does not yet get the necessary attention in research and in teaching. All this applies to simulation software in particular.
 
@@ -13,6 +13,12 @@ Read more:
 
 - Association of German Research Software Engineers: [de-RSE](https://de-rse.org/en/)
 - [Position paper of de-RSE](https://f1000research.com/articles/9-295/v2)
+
+## Idea of the course
+
+The course is about simulation software. More precisely, we discuss the software tools used to ensure good software engineering for open-source simulation software such as FEniCS, PETSc, TRILINOS, DuMuX, preCICE, or SU2. This is not a course focused on programming and programming paradigms, but on the techniques and the corresponding tools. Some examples are version control (Git, GitHub, GitLab), virtualization/containerization (Docker), continuous integration (GitHub Actions, GitLab CI), or documentation  (Jekyll, mkdocs, sphinx). We study these concepts and tools in lectures and (almost) weekly lab assignments. 
+In parallel, you work on an individual challenge, where you apply the learned concepts and tools with the ultimate goal to contribute to a large-scale community simulation software package.
+[Read more on the course content](course-content.md).
 
 ## Target audience
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,14 @@
 # Simulation Software Engineering
 
-!!! note
-    This page is under construction and will be updated regularly.
-
 !!! info "Lecture and exercise in winter term 21/22"
     We plan to have **on-site** lectures and exercises. Please contact us if you cannot join on-site, but only online.
 
-Welcome to the homepage of the course "Simulation Software Engineeering" at the University of Stuttgart. The homepage is currently under construction, but you can already find general information about the course under [course information](course-information.md) and in the video below
+Welcome to the homepage of the course "Simulation Software Engineeering" at the University of Stuttgart. 
+You find general information about the course under [course information](course-information.md) and in the video below.
 
 <p align="center">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/1GUVWLSxt2s" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </p>
 
-If you have any further questions or suggestions, please contact the [instructors](staff.md).
+More details on the [course content](course-content) and the [place and time](place-and-time.md).
+If you have any questions or suggestions, please contact the [instructors](staff.md).

--- a/docs/place-and-time.md
+++ b/docs/place-and-time.md
@@ -4,6 +4,7 @@ title: Place and time
 description: >-
     Time table and lecture hall
 ---
+
 ## Lecture hall
 
 All sessions take place in [38.04](https://campus.uni-stuttgart.de/cusonline/pl/ui/$ctx;lang=DE/ris.ris?pOrgNr=599&pQuellGeogrBTypNr=5&pZielGeogrBTypNr=5&pZielGeogrBerNr=6050009&pRaumNr=7051&pActionFlag=A&pShowEinzelraum=J), Universitätsstr. 38, ground floor.
@@ -52,5 +53,3 @@ Please note that we might adjust the time table during the semester.
 |   13.2 | 03.02. |Lecture | 7 | tbd. | |
 |   14.1 | 10.02. |Presentations | C | final student presentations | students|
 |   14.2 | 10.02. |Presentations | C | final student presentations | students| 
-
-

--- a/docs/place-and-time.md
+++ b/docs/place-and-time.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Time and place
+title: Place and time
 description: >-
     Time table and lecture hall
 ---

--- a/docs/time-and-place.md
+++ b/docs/time-and-place.md
@@ -1,0 +1,56 @@
+---
+layout: page
+title: Time and place
+description: >-
+    Time table and lecture hall
+---
+## Lecture hall
+
+All sessions take place in [38.04](https://campus.uni-stuttgart.de/cusonline/pl/ui/$ctx;lang=DE/ris.ris?pOrgNr=599&pQuellGeogrBTypNr=5&pZielGeogrBTypNr=5&pZielGeogrBerNr=6050009&pRaumNr=7051&pActionFlag=A&pShowEinzelraum=J), Universitätsstr. 38, ground floor.
+We plan to do the complete course **on site**. As the course is heavy on interactive labs, a hybrid mode seems not very suitable. Please contact us if you can only join online nonetheless. If needed, we will find a solution.
+
+## Time
+
+Lectures and lab work are both on Thursdays:
+
+* 09:45–11:15
+* 15:45–17:15
+
+There is not strict distinction between both slots. It depends on the topic and the week. Normally, we do a more lecture-style session in the morning and a more lab-style session in the afternoon.
+
+## Time table
+
+Please note that we might adjust the time table during the semester.
+
+| Week | Date | Type | Chapter | Topic | Lecturer |
+| ---- | ---- | ---- | ------- |------ | -------- |
+|    1.1 | 21.10. |Lecture | 1-2 | course intro, intro to SSE, VC basics | Benjamin |
+|    1.2 | 21.10. |Lecture | 2 | Git: my workflow + quiz, software projects for challenge  | Benjamin |
+|    2.1 | 28.10. |Lecture + presentations| 2 | *my neat little Git trick*, merge vs rebase, working in teams| Benjamin |
+|    2.2 | 28.10. |Lab | 2 | *Git cheat sheet*  | Benjamin |
+|    3.1 | 04.11. |Lecture | 3 | Virtualbox, Vagrant | Alex |
+|    3.2 | 04.11. |Lecture | 3 | Docker, Singularity | Alex |
+|    4.1 | 11.11. |Lab | 3 | tbd.  | Alex |
+|    4.2 | 11.11. |Presentations | C | 1st student presentations | students|
+|    5.1 | 18.11. |Lecture | 4 | CMake | |
+|    5.2 | 18.11. |Lab | 4 | CMake | |
+|    6.1 | 25.11. |Lecture | 4 | Packaging and package managers, pip, conda | Ishaan |
+|    6.2 | 25.11. |Lab | 4 | pip and PyPI exercise | Ishaan |
+|    7.1 | 02.12. |Lecture | 4 | tbd. |  |
+|    7.2 | 02.12. |Lab | 4 | tbd. | |
+|    8.1 | 09.12. |Lecture | 5 | documentation tools | Alex |
+|    8.2 | 09.12. |Lab | 5 | tbd. |  |
+|    9.1 | 16.12. |Lecture | 5 | Technical writing | Benjamin |
+|    9.2 | 16.12. |Presentations | C | 2nd student presentations | students |
+|   10.1 | 13.01. |Lecture | 6 | tbd. | |
+|   10.2 | 13.01. |Lab | 6 | tbd. | |
+|   11.1 | 20.01. |Lecture | 6 | tbd. | |
+|   11.2 | 20.01. |Lab | 6 | tbd. | |
+|   12.1 | 27.01. |Lecture | 7 | tbd. | |
+|   12.2 | 27.01. |Lab | 7 | tbd. | |
+|   13.1 | 03.02. |Lecture | 7 | tbd. | |
+|   13.2 | 03.02. |Lecture | 7 | tbd. | |
+|   14.1 | 10.02. |Presentations | C | final student presentations | students|
+|   14.2 | 10.02. |Presentations | C | final student presentations | students| 
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ site_description: >-
 nav:
   - Simulation Software Engineering: index.md
   - Course information: course-information.md
+  - Course content: course-content.md
   - Staff/Contact: staff.md
 
 # Point to repository name and set base branch to main

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Simulation Software Engineering: index.md
   - Course information: course-information.md
   - Course content: course-content.md
+  - Time and place: time-and-place.md
   - Staff/Contact: staff.md
 
 # Point to repository name and set base branch to main

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ nav:
   - Simulation Software Engineering: index.md
   - Course information: course-information.md
   - Course content: course-content.md
-  - Time and place: time-and-place.md
+  - Place and time: place-and-time.md
   - Staff/Contact: staff.md
 
 # Point to repository name and set base branch to main


### PR DESCRIPTION
This PR adds an additional page for the course content.

- I moved information ("Assignments and lab work" and "course contents") to the new page called "course content".
- I added the seven chapters to the subsection "Course's contents"
- Added the learning goals to the chapter's description. If we did not have learning goals yet, I wrote some.
- Some slight reformulation.

*Issue*
- Learning goals on the homepage and in the lecture plannings (`overview.md`) might get out of sync.