### PR TITLE
Fix manual action for publishing homepage

### DIFF
--- a/.github/workflows/publish-homepage-manually.yml
+++ b/.github/workflows/publish-homepage-manually.yml
@@ -1,8 +1,0 @@
-name: Manually triggered publication of homepage
-on:
-  workflow_dispatch
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/actions/my-action@v1

--- a/.github/workflows/publish-homepage.yml
+++ b/.github/workflows/publish-homepage.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - main
-  workflow_dispatch
+  workflow_dispatch:
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-homepage.yml
+++ b/.github/workflows/publish-homepage.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The initial PR #7  could not build the homepage manually as the action was broken.