### PR TITLE
Add automatic link checking

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         ruby-version: 2.6.x
     - name: Check links
-      #FIXME Need to whitelist the US3 homepage as it created a duplication error.
+      #FIXME Need to allow duplicates (same links on the same page)
       run: |
         gem install awesome_bot
-        awesome_bot docs/*.md --white-list https://www.ipvs.uni-stuttgart.de/departments/us3/
+        awesome_bot docs/*.md README.md --allow-dupe

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,0 +1,24 @@
+name: Link checker
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Check links
+      #FIXME Need to whitelist the US3 homepage as it created a duplication error.
+      run: |
+        gem install awesome_bot
+        awesome_bot docs/*.md --white-list https://www.ipvs.uni-stuttgart.de/departments/us3/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![publish-homepage](https://github.com/Simulation-Software-Engineering/homepage/actions/workflows/publish-homepage.yml/badge.svg)
 ![markdownlint](https://github.com/Simulation-Software-Engineering/homepage/actions/workflows/markdownlint.yml/badge.svg)
+![linkchecker](https://github.com/Simulation-Software-Engineering/homepage/actions/workflows/linkchecker.yml/badge.svg)
 
 This repository contains the content of for the homepage of the "Simulation Software Engineering" lecture at the University of Stuttgart (Germany). The homepage is built on [mkdocs](https://www.mkdocs.org), the ["Material for MkDocs" theme](https://squidfunk.github.io/mkdocs-material/), and corresponding plugins.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,16 @@ After installing all dependencies change into this directory (the directory cont
 
 The markdown files can be checked using [markdownlint](https://github.com/markdownlint/markdownlint/). Once the linter is installed one can run it locally from the root of this repository using
 
-```
+```bash
 mdl docs/
 ```
 
 It will automatically read the markdownlint configuration of this repository. The linter is configured in the files `.mdl.rb` and `.mdlrc`. The majority of the configuration is done in `.mdl.rb`.
+
+## Link checking
+
+We currently check links via [awesome_bot](https://github.com/dkhamsing/awesome_bot). If you want to run the checks locally, you must install the `awesome_bot` gem and then run the following command from the root of the repository:
+
+```bash
+awesome_bot docs/*.md README.md --allow-dupe
+```


### PR DESCRIPTION
This PR adds automatic link checking for the markdown files. We had outdated links after I had updated some file names in the material repository.