### PR TITLE
Add link to system paths and library tools

### DIFF
--- a/docs/place-and-time.md
+++ b/docs/place-and-time.md
@@ -35,8 +35,8 @@ Please note that we might adjust the time table during the semester. You find a 
 |    4.2 | 11.11. |Presentations | C | 1st student presentations | students|
 |    5.1 | 18.11. |Lecture | 4 | Packaging and package managers, pip, conda | Ishaan |
 |    5.2 | 18.11. |Lab | 4 | pip and PyPI exercise | Ishaan |
-|    6.1 | 25.11. |Lecture | 4 | CMake | |
-|    6.2 | 25.11. |Lab | 4 | CMake | |
+|    6.1 | 25.11. |Lecture | 4 | [Paths and Library Tools](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/systempaths-and-librarytools_slides.md), CMake | Alexander and Benjamin |
+|    6.2 | 25.11. |Lab | 4 | CMake | Benjamin |
 |    7.1 | 02.12. |Lecture | 4 | tbd. |  |
 |    7.2 | 02.12. |Lab | 4 | tbd. | |
 |    8.1 | 09.12. |Lecture | 5 | documentation tools | Alexander |


### PR DESCRIPTION
This PR adds the link to the system paths and library tools.

Should be updated and merged after https://github.com/Simulation-Software-Engineering/Lecture-Material/pull/38 has been merged.